### PR TITLE
Fixed Countable::count return type

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -160,7 +160,7 @@ class Menu implements Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->menu);
     }

--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -559,7 +559,7 @@ class MenuBuilder implements Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->items);
     }


### PR DESCRIPTION
A warning for return type compatibility is thrown for Menu::count and MenuBuilder::count because of the Countable::count return type.